### PR TITLE
Fixing pymongo aggregate function

### DIFF
--- a/flask_profiler/storage/mongo.py
+++ b/flask_profiler/storage/mongo.py
@@ -264,7 +264,7 @@ class Mongo(BaseStorage):
         :param pipeline: {list} of aggregation pipeline stages
         :return: {pymongo.command_cursor.CommandCursor}
         """
-        result = self.connection.aggregate(pipeline, **kwargs)
+        result = self.collection.aggregate(pipeline, **kwargs)
         if pymongo.version_tuple < (3, 0, 0):
             result = result['result']
 


### PR DESCRIPTION
Return value of pymongo function `aggregate` has been changed since version 3.0.0. Previous versions has been returning `Cursor` and you had to call `result['result']` to get actual output. Since 3.0.0 it's returning result directly. So i have added helper method to check on what version of pymongo you are running end extract output if its necessary.

Currently i am using pymongo 3.2.2 and i am not able tu use Mongo storage engine.