### PR TITLE
Fix truncation of exception traceback

### DIFF
--- a/flask_profiler/flask_profiler.py
+++ b/flask_profiler/flask_profiler.py
@@ -81,8 +81,8 @@ def measure(f, name, method, context=None):
 
         try:
             returnVal = f(*args, **kwargs)
-        except Exception as e:
-            raise e
+        except:
+            raise
         finally:
             measurement.stop()
             if CONF.get("verbose", False):


### PR DESCRIPTION
Today we've realized that our API exception tracebacks are being truncated when we have flask-profiler turned on. After short research, we've discovered that the exception's stack trace is rewritten because of the way exception is re-rised.

```
except Exception as e:
    raise e
```

Instead of this approach, just blank `raise` can be used. It keeps the old traceback.