### PR TITLE
Compatibility with Flask 0.11

### DIFF
--- a/flask_profiler/flask_profiler.py
+++ b/flask_profiler/flask_profiler.py
@@ -8,7 +8,7 @@ from pprint import pprint as pp
 from flask import Blueprint
 from flask import jsonify
 from flask import request
-from flask.ext.httpauth import HTTPBasicAuth
+from flask_httpauth import HTTPBasicAuth
 
 from . import storage
 


### PR DESCRIPTION
In Flask 0.11 `flask.ext.` imports raise a deprecation exception, so `flask.ext.httpauth` is now just `flask_httpauth`