### PR TITLE
Add production usage support by configurable sampling function

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,27 @@ The other options are listed below.
 | storage.DATABASE | database name | flask_profiler
 | storage.COLLECTION | collection name | measurements
 
+### Sampling
+Control the number of samples taken by flask-profiler
+
+You would want control over how many times should the flask profiler take samples while running in production mode. 
+You can supply a function and control the sampling according to your business logic.
+
+Example 1: Sample 1 in 100 times with random numbers
+```json
+app.config["flask_profiler"] = {
+    "sampling_function": True if random.sample(list(range(1, 101)), 1) == [42] else False
+}
+```
+
+Example 2: Sample for specific users
+```json
+app.config["flask_profiler"] = {
+    "sampling_function": True if user is 'divyendu' else False
+}
+```
+
+If sampling function is not present, all requests will be sampled.
 
 ## Contributing
 

--- a/flask_profiler/flask_profiler.py
+++ b/flask_profiler/flask_profiler.py
@@ -75,6 +75,9 @@ class Measurement(object):
 def measure(f, name, method, context=None):
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
+        if 'sampling_function' in CONF and not CONF['sampling_function']():
+            return f(*args, **kwargs)
+
         measurement = Measurement(name, args, kwargs, method, context)
         measurement.start()
 


### PR DESCRIPTION
On high traffic websites, it is not ideal to sample each request via flask-profiler.
This commit provides an option to send a sampling function (provided by user)  as configuration parameter.

If the sampling function returns True, sample is taken, if sampling function is not defined or returns False, sample is not taken.

README.md is also edited in this commit to give a couple of usage examples.

When merged, this will resolve issue # https://github.com/muatik/flask-profiler/issues/44