### PR TITLE
in case when use app.config.from_object ,the key must is always upper

### DIFF
--- a/flask_profiler/flask_profiler.py
+++ b/flask_profiler/flask_profiler.py
@@ -222,11 +222,14 @@ def init_app(app):
 
     try:
         CONF = app.config["flask_profiler"]
-    except Exception:
-        raise Exception(
-            "to init flask-profiler, provide "
-            "required config through flask app's config. please refer: "
-            "https://github.com/muatik/flask-profiler")
+    except:
+        try:
+            CONF = app.config["FLASK_PROFILER"]
+        except:
+            raise Exception(
+                "to init flask-profiler, provide "
+                "required config through flask app's config. please refer: "
+                "https://github.com/muatik/flask-profiler")
 
     if not CONF.get("enabled", False):
         return


### PR DESCRIPTION
Hi all:

when you use the app.config.from_object(obj) 

```
    def from_object(self, obj):
        """Updates the values from the given object.  An object can be of one
        of the following two types:

        -   a string: in this case the object with that name will be imported
        -   an actual object reference: that object is used directly

        Objects are usually either modules or classes.

        Just the uppercase variables in that object are stored in the config.
        Example usage::

            app.config.from_object('yourapplication.default_config')
            from yourapplication import default_config
            app.config.from_object(default_config)

        You should not use this function to load the actual configuration but
        rather configuration defaults.  The actual config should be loaded
        with :meth:`from_pyfile` and ideally from a location not within the
        package because the package might be installed system wide.

        :param obj: an import name or object
        """
        if isinstance(obj, basestring):
            obj = import_string(obj)
        for key in dir(obj):
            if key.isupper():
                self[key] = getattr(obj, key)
```

all the key is upper ,so in case when you use method ,we should consider this situation.