### PR TITLE
Feature/standard initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,45 @@ curl -X PUT -d arg1=val1 http://127.0.0.1:5000/product/123
 
 If everything is okay, Flask-profiler will measure these requests. You can see the result heading to http://127.0.0.1:5000/flask-profiler/ or get results as JSON http://127.0.0.1:5000/flask-profiler/api/measurements?sort=elapsed,desc
 
+If you like to initialize your extensions in other files or use factory apps pattern, you can also create a instance of the `Profiler` class, this will register all your endpoints once you app run by first time. E.g:
+
+```python
+from flask import Flask
+from flask_profiler import Profiler
+
+profiler = Profiler()
+
+app = Flask(__name__)
+
+app.config["DEBUG"] = True
+
+# You need to declare necessary configuration to initialize
+# flask-profiler as follows:
+app.config["flask_profiler"] = {
+    "enabled": app.config["DEBUG"],
+    "storage": {
+        "engine": "sqlite"
+    },
+    "basicAuth":{
+        "enabled": True,
+        "username": "admin",
+        "password": "admin"
+    },
+    "ignore": [
+        "^/static/.*"
+    ]
+}
+
+profiler = Profiler()  # You can have this in another module
+profiler.init_app(app)
+# Or just Profiler(app)
+
+@app.route('/product/<id>', methods=['GET'])
+def getProduct(id):
+    return "product id is " + str(id)
+
+```
+
 ## Using with different database system
 Currently, **SQLite** and **MongoDB** database systems are supported. However, it is easy to support other database systems. If you would like to have others, please go to contribution documentation. (It is really easy.)
 

--- a/flask_profiler/__init__.py
+++ b/flask_profiler/__init__.py
@@ -2,4 +2,5 @@
 from .flask_profiler import (
     measure,
     profile,
-    init_app)
+    init_app,
+    Profiler)

--- a/flask_profiler/flask_profiler.py
+++ b/flask_profiler/flask_profiler.py
@@ -266,3 +266,16 @@ def init_app(app):
     basicAuth = CONF.get("basicAuth", None)
     if not basicAuth or not basicAuth["enabled"]:
         logging.warn(" * CAUTION: flask-profiler is working without basic auth!")
+
+
+class Profiler(object):
+    """ Wrapper for extension. """
+
+    def __init__(self, app=None):
+        self._init_app = init_app
+        if app is not None:
+            self.init_app(app)
+
+    def init_app(self, app):
+        init = functools.partial(self._init_app, app)
+        app.before_first_request(init)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,7 +6,7 @@ import sys
 
 from .test_endpoint_ignore import EndpointIgnoreTestCase
 from .test_measurement import MeasurementTest
-from .test_measure_endpoint import EndpointMeasurementTest
+from .test_measure_endpoint import EndpointMeasurementTest, EndpointMeasurementTest2
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
@@ -15,4 +15,5 @@ def suite():
     suite.addTest(unittest.makeSuite(MeasurementTest))
     suite.addTest(unittest.makeSuite(EndpointMeasurementTest))
     suite.addTest(unittest.makeSuite(EndpointIgnoreTestCase))
+    suite.addTest(unittest.makeSuite(EndpointMeasurementTest2))
     return suite

--- a/tests/basetest.py
+++ b/tests/basetest.py
@@ -91,3 +91,31 @@ class BasetTest(unittest.TestCase):
             return "with profiler"
 
         return app
+
+
+class BaseTest2(unittest.TestCase):
+
+    def setUp(cls):
+        flask_profiler.collection.truncate()
+
+    @classmethod
+    def setUpClass(cls):
+
+        flask_profiler.collection = storage.getCollection(CONF["storage"])
+
+    def create_app(self):
+        app = Flask(__name__)
+        app.config["flask_profiler"] = CONF
+        app.config['TESTING'] = True
+        profiler = flask_profiler.Profiler()
+        profiler.init_app(app)
+
+        @app.route("/api/people/<firstname>")
+        def sayHello(firstname):
+            return firstname
+
+        @app.route("/api/with/profiler/<message>")
+        def customProfilerEP(message):
+            return "with profiler"
+
+        return app


### PR DESCRIPTION
#67 
Add Profiler class, is a wrapper for init_app func, which hooks in flask `before_first_request_funcs ` list. This way all endpoints are registered no matter when you initialize the profiler.