### PR TITLE
Explicitly autoincrement the ID

### DIFF
--- a/flask_profiler/storage/sql_alchemy.py
+++ b/flask_profiler/storage/sql_alchemy.py
@@ -19,7 +19,7 @@ def formatDate(timestamp, dateFormat):
 class Measurements(base):
     __tablename__ = 'flask_profiler_measurements'
 
-    id = Column(Integer, primary_key=True)
+    id = Column(Integer, primary_key=True, autoincrement=True)
     startedAt = Column(Numeric)
     endedAt = Column(Numeric)
     elapsed = Column(Numeric(10, 4))


### PR DESCRIPTION
SAP HANA doesn't autoincrement by default, so `flask_profiler` doesn't work with that RDBMS.