### PR TITLE
docs: Fix a few typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ tl;dr: Contributors should follow the standard team development practices.
 * Check for unnecessary whitespace with git diff --check before committing.
 * Make sure your commit messages are in the proper format.
 * If your commit fixes an open issue, reference it in the commit message (#15).
-* Make sure your code comforms to [PEP8](https://www.python.org/dev/peps/pep-0008/).
+* Make sure your code conforms to [PEP8](https://www.python.org/dev/peps/pep-0008/).
 * Make sure you have added the necessary tests for your changes.
 * Run all the tests to assure nothing else was accidentally broken.
 

--- a/examples/app.py
+++ b/examples/app.py
@@ -53,7 +53,7 @@ flask_profiler.init_app(app)
 
 
 # endpoint declarations after flask_profiler.init_app() will be
-# hidden to flask_profider.
+# hidden to flask_profiler.
 @app.route('/doSomething', methods=['GET'])
 def doSomething():
     return "flask-provider will not measure this."

--- a/flask_profiler/storage/mongo.py
+++ b/flask_profiler/storage/mongo.py
@@ -263,7 +263,7 @@ class Mongo(BaseStorage):
 
     def aggregate(self, pipeline, **kwargs):
         """Perform an aggregation and make sure that result will be everytime
-        CommandCursor. Will take care for pymongo version differencies
+        CommandCursor. Will take care for pymongo version differences
         :param pipeline: {list} of aggregation pipeline stages
         :return: {pymongo.command_cursor.CommandCursor}
         """


### PR DESCRIPTION
There are small typos in:
- CONTRIBUTING.md
- examples/app.py
- flask_profiler/storage/mongo.py

Fixes:
- Should read `profiler` rather than `profider`.
- Should read `conforms` rather than `comforms`.
- Should read `differences` rather than `differencies`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md